### PR TITLE
fix: metadata may sometimes be empty

### DIFF
--- a/custom_components/cloudflare_speed_test/manifest.json
+++ b/custom_components/cloudflare_speed_test/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DigitallyRefined/ha-cloudflare-speed-test/issues",
   "requirements": [
-    "git+https://github.com/martinbrose/cloudflarepycli.git@c13517b9d9031c4ec1552a76c848e36ba2dd094f#egg=cloudflarepycli"
+    "cloudflarepycli@git+https://github.com/martinbrose/cloudflarepycli@c13517b9d9031c4ec1552a76c848e36ba2dd094f"
   ],
-  "version": "0.0.3-dev"
+  "version": "0.0.3-dev2"
 }

--- a/custom_components/cloudflare_speed_test/manifest.json
+++ b/custom_components/cloudflare_speed_test/manifest.json
@@ -6,6 +6,8 @@
   "documentation": "https://github.com/DigitallyRefined/ha-cloudflare-speed-test",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DigitallyRefined/ha-cloudflare-speed-test/issues",
-  "requirements": ["cloudflarepycli==2.0.2"],
-  "version": "0.0.2"
+  "requirements": [
+    "git+https://github.com/martinbrose/cloudflarepycli.git@c13517b9d9031c4ec1552a76c848e36ba2dd094f#egg=cloudflarepycli"
+  ],
+  "version": "0.0.3-dev"
 }

--- a/custom_components/cloudflare_speed_test/manifest.json
+++ b/custom_components/cloudflare_speed_test/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/DigitallyRefined/ha-cloudflare-speed-test/issues",
   "requirements": [
-    "cloudflarepycli@git+https://github.com/martinbrose/cloudflarepycli@c13517b9d9031c4ec1552a76c848e36ba2dd094f"
+    "cloudflarepycli@git+https://github.com/DigitallyRefined/cloudflarepycli.git@v2.1.0"
   ],
   "version": "0.0.3-dev2"
 }

--- a/custom_components/cloudflare_speed_test/manifest.json
+++ b/custom_components/cloudflare_speed_test/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "cloudflarepycli@git+https://github.com/DigitallyRefined/cloudflarepycli.git@v2.1.0-rc"
   ],
-  "version": "0.0.3-dev2"
+  "version": "0.0.3"
 }

--- a/custom_components/cloudflare_speed_test/sensor.py
+++ b/custom_components/cloudflare_speed_test/sensor.py
@@ -198,25 +198,23 @@ class CloudflareSpeedTestSensor(
         """Return native value for entity."""
         if self.coordinator.data:
             location = "meta" if self.entity_description.key == "ip" else "tests"
-            state = self.coordinator.data[location][self.entity_description.key].value
-            self._state = cast(StateType, self.entity_description.value(state))
+            location_dict = self.coordinator.data.get(location, {})
+            value_obj = location_dict.get(self.entity_description.key, {})
+            state = getattr(value_obj, "value")
+            if state is not None:
+                self._state = cast(StateType, self.entity_description.value(state))
         return self._state
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         if self.coordinator.data:
+            meta = self.coordinator.data.get("meta", {})
             self._attrs.update(
                 {
-                    ATTR_SERVER_CITY: self.coordinator.data["meta"][
-                        "location_city"
-                    ].value,
-                    ATTR_SERVER_REGION: self.coordinator.data["meta"][
-                        "location_region"
-                    ].value,
-                    ATTR_SERVER_CODE: self.coordinator.data["meta"][
-                        "location_code"
-                    ].value,
+                    ATTR_SERVER_CITY: getattr(meta.get("location_city"), "value"),
+                    ATTR_SERVER_REGION: getattr(meta.get("location_region"), "value"),
+                    ATTR_SERVER_CODE: getattr(meta.get("location_code"), "value"),
                 }
             )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.9.0
 homeassistant==2025.3.0
 pip>=21.3.1
 ruff==0.12.8
-cloudflarepycli@git+https://github.com/martinbrose/cloudflarepycli@c13517b9d9031c4ec1552a76c848e36ba2dd094f
+cloudflarepycli@git+https://github.com/DigitallyRefined/cloudflarepycli.git@v2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog==6.9.0
 homeassistant==2025.3.0
 pip>=21.3.1
 ruff==0.12.7
-cloudflarepycli==2.0.2
+git+https://github.com/martinbrose/cloudflarepycli.git@c13517b9d9031c4ec1552a76c848e36ba2dd094f#egg=cloudflarepycli


### PR DESCRIPTION
In some cases the metadata returned from `cloudflarepycli` would be empty, this would cause the component to fail to record the speed test result.

Fixes #28